### PR TITLE
fix(editorconfig): override `trim_trailing_whitespace` handler

### DIFF
--- a/lua/KoalaVim/plugins/editor.lua
+++ b/lua/KoalaVim/plugins/editor.lua
@@ -318,6 +318,10 @@ table.insert(M, {
 		},
 	},
 	config = function(_, opts)
+		-- Overriding neovim's default whitespace trim autocmd, clashes with autosave
+		---@diagnostic disable-next-line: duplicate-set-field
+		require('editorconfig').properties.trim_trailing_whitespace = function() end
+
 		local retrail = require('retrail')
 		retrail.setup(opts)
 		usercmd.create('TrimWhiteSpace', 'Remove line ending whitespace', function()


### PR DESCRIPTION
Resolves an issue where neovim's default handler for `trim_trailing_whitespace` would clash on autosave, which caused an "undo loop".