### PR TITLE
fix(treesitter): get language from filetype

### DIFF
--- a/lua/KoalaVim/plugins/treesitter.lua
+++ b/lua/KoalaVim/plugins/treesitter.lua
@@ -16,11 +16,12 @@ table.insert(M, {
 
 		local usercmd = require('KoalaVim.utils.cmd')
 		local function _enable_ts(ft, bufid)
-			if vim.tbl_contains(available_langs, ft) then
+			local lang = vim.treesitter.language.get_lang(ft)
+			if vim.tbl_contains(available_langs, lang) then
 				enabled[bufid] = true
 
 				-- install if not exist
-				require('nvim-treesitter').install(ft):await(function()
+				require('nvim-treesitter').install(lang):await(function()
 					-- syntax highlighting, provided by Neovim
 					vim.treesitter.start(bufid)
 					-- folds, provided by Neovim


### PR DESCRIPTION
## 🐞 Bug
Treesitter highlighting wasn't working for `.tsx` files, since their filetype is `typescriptreact` but the treesitter parser name is `tsx`

## 🔧 Fix
Fixed using [vim.treesitter.language.get_lang](https://neovim.io/doc/user/treesitter/#vim.treesitter.language.get_lang())

LazyVim ref: https://github.com/LazyVim/LazyVim/blob/c64a61734fc9d45470a72603395c02137802bc6f/lua/lazyvim/util/treesitter.lua#L36