### PR TITLE
lsp: diagnostics ui fixes

### DIFF
--- a/lua/KoalaVim/plugins/lsp/general.lua
+++ b/lua/KoalaVim/plugins/lsp/general.lua
@@ -454,6 +454,8 @@ table.insert(M, {
 	},
 	config = function(_, opts)
 		require('diagflow').setup(opts)
+		-- diagflow uses vim.fn.sign_getdefined to get diagnostic icons
+		require('KoalaVim.utils.lsp').setup_diagnostic_signs()
 		vim.api.nvim_create_autocmd('InsertEnter', {
 			callback = require('KoalaVim.utils.lsp').disable_diagflow,
 		})

--- a/lua/KoalaVim/utils/lsp.lua
+++ b/lua/KoalaVim/utils/lsp.lua
@@ -141,6 +141,14 @@ local DIAGNOSTICS_CFG = {
 
 local CURR_DIAG_CFG = DIAGNOSTICS_CFG[0]
 
+function M.setup_diagnostic_signs()
+	local icons = require('KoalaVim.utils.icons').diagnostics
+	for severity, name in pairs(require('KoalaVim.utils.icons').severity_to_name) do
+		local hlname = 'DiagnosticSign' .. name:gsub('^%l', string.upper)
+		vim.fn.sign_define(hlname, { text = icons[name], texthl = hlname, numhl = '' })
+	end
+end
+
 local _signs = nil
 
 function M.set_diagnostics_mode(index)
@@ -157,12 +165,13 @@ function M.set_diagnostics_mode(index)
 			local hlname = name:gsub('^%l', string.upper) -- Captial first letter
 			hlname = 'DiagnosticSign' .. hlname
 			_signs.text[severity] = icons[name]
-			_signs.linehl[severity] = name
+			_signs.linehl[severity] = ''
 			_signs.numhl[severity] = ''
 		end
 	end
 	CURR_DIAG_CFG = DIAGNOSTICS_CFG[index]
 	CURR_DIAG_CFG.update_in_insert = false
+	CURR_DIAG_CFG.underline = false
 	CURR_DIAG_CFG.signs = _signs
 
 	vim.diagnostic.config(CURR_DIAG_CFG)


### PR DESCRIPTION
Setup severity icons via `vim.fn.sign_define` so `diagflow` can read them with `vim.fn.sign_getdefined` ([ref](https://github.com/ofirgall/diagflow.nvim/blob/5a35692126ff0bf4cb727e5606043fd9f84fc451/lua/diagflow/lazy.lua#L111-L113)).

Also disable underline and line highlight in diagnostics config.