### PR TITLE
feat(vtsls): allow to configure `maxTsServerMemory`

### DIFF
--- a/config_scheme.jsonc
+++ b/config_scheme.jsonc
@@ -119,6 +119,16 @@
             "description": "Language server protocol settings (intellisense)",
             "type": "object",
             "properties": {
+                "vtsls": {
+                    "description": "TypeScript/JavaScript language server settings",
+                    "type": "object",
+                    "properties": {
+                        "max_memory": {
+                            "description": "Max memory for tsserver in MB (maps to maxTsServerMemory)",
+                            "type": ["integer", "null"]
+                        }
+                    }
+                },
                 "autoformat": {
                     "description": "Auto formatting options",
                     "type": "object",

--- a/default_kvim.conf
+++ b/default_kvim.conf
@@ -22,6 +22,9 @@
         }
     },
     "lsp": {
+        "vtsls": {
+            "max_memory": null
+        },
         "autoformat": {
             "blacklist": [
                 "clangd"

--- a/lua/KoalaVim/plugins/lsp/general.lua
+++ b/lua/KoalaVim/plugins/lsp/general.lua
@@ -44,6 +44,19 @@ table.insert(M, {
 		LSP_CAPS = require('cmp_nvim_lsp').default_capabilities(vim.lsp.protocol.make_client_capabilities())
 		LSP_CAPS.textDocument.completion.completionItem.labelDetailsSupport = nil -- Overriding with false doesn't work for some reason
 
+		-- Apply user vtsls config from .kvim.conf
+		local vtsls_conf = require('KoalaVim').conf.lsp.vtsls
+		if vtsls_conf.max_memory then
+			LSP_SERVERS['vtsls'] = vim.tbl_deep_extend('force', LSP_SERVERS['vtsls'] or {}, {
+				settings = {
+					typescript = {
+						tsserver = {
+							maxTsServerMemory = vtsls_conf.max_memory,
+						},
+					},
+				},
+			})
+		end
 		local function setup_server(server)
 			-- FIXME: vim.lsp: re-visit capabilities, on_attach and on_init
 			local server_opts_merged = vim.tbl_deep_extend('force', {

--- a/lua/KoalaVim/plugins/lsp/general.lua
+++ b/lua/KoalaVim/plugins/lsp/general.lua
@@ -46,7 +46,7 @@ table.insert(M, {
 
 		-- Apply user vtsls config from .kvim.conf
 		local vtsls_conf = require('KoalaVim').conf.lsp.vtsls
-		if vtsls_conf.max_memory then
+		if vtsls_conf.max_memory and vtsls_conf.max_memory ~= vim.NIL then
 			LSP_SERVERS['vtsls'] = vim.tbl_deep_extend('force', LSP_SERVERS['vtsls'] or {}, {
 				settings = {
 					typescript = {


### PR DESCRIPTION
Needed for large TS projects as `tsserver` tends to crash :(

(Temp solution until we get to "Koala-over-LazyVim" phase)