### PR TITLE
fix(codediff): disable `format-on-leave` safely

### DIFF
--- a/lua/KoalaVim/utils/git.lua
+++ b/lua/KoalaVim/utils/git.lua
@@ -12,7 +12,9 @@ end
 
 function M.show_diff()
 	if vim.env.KOALA_CODE_DIFF == 'true' then
-		pcall(function() require('format-on-leave').disable() end)
+		pcall(function()
+			require('format-on-leave').disable()
+		end)
 		vim.cmd('CodeDiff')
 	else
 		vim.cmd('DiffviewOpen')

--- a/lua/KoalaVim/utils/git.lua
+++ b/lua/KoalaVim/utils/git.lua
@@ -12,7 +12,7 @@ end
 
 function M.show_diff()
 	if vim.env.KOALA_CODE_DIFF == 'true' then
-		require('format-on-leave').disable()
+		pcall(function() require('format-on-leave').disable() end)
 		vim.cmd('CodeDiff')
 	else
 		vim.cmd('DiffviewOpen')


### PR DESCRIPTION
Explodes on init if user disabled the plugin in their config.