### PR TITLE
docs: rewrite README to feature kv and surface configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,61 +2,116 @@
 
 # KoalaVim
 
-
-Extendable preconfigured configuration for Neovim powered by [lazy.nvim](https://github.com/folke/lazy.nvim).
-NVIM version: v0.11.5
+Extensible Neovim distribution, powered by [lazy.nvim](https://github.com/folke/lazy.nvim) and managed by [`kv`](https://github.com/KoalaVim/kv).
 
 <br><br><br><br><br><br>
 
 ---
 
-## 🚧 **This configuration is in an early alpha stage** 🚧
+## 🚧 KoalaVim is in early alpha. Expect breaking changes. 🚧
 
-# Installation
-* Make a backup for your current nvim configuration 
-    ```bash
-    mv ~/.config/nvim ~/.config/nvim.bak
-    mv ~/.local/share/nvim ~/.local/share/nvim.bak
-    ```
-* Optional: copy [KoalaConfig.template](https://github.com/KoalaVim/KoalaConfig.template) (Use this template)
-* Clone your config or the template
-    ```bash
-    git clone https://github.com/<your_github_username>/KoalaConfig ~/.config/nvim
+## Features
 
-    ### Clone the template if you didn't make a copy
-    git clone https://github.com/KoalaVim/KoalaConfig.template ~/.config/nvim
-    # Remove .git if you want to push it as yours later
-    rm -rf ~/.config/nvim/.git
-    ```
+- AI sidekick integration with Claude, Codex, Cursor, and opencode CLI agents inside Neovim.
+- Git-aware launch modes (diff, status, tree).
+- Modal sub-modes via [Hydra](docs/plugins/hydra.md).
+- Curated plugin set across 16 categories — see [`docs/plugins/`](docs/plugins/README.md).
+- Isolated virtual environments via [`kv`](https://github.com/KoalaVim/kv).
+- JSON-schema-validated user config.
 
-Note: currently KoalaVim install all treesitter's parsers so the first launch might be laggy. It's highly recommended to restart nvim after treesitter's finish installs all the parsers.
+## Requirements
 
-### For Devs
-Run the following command in KoalaVim repo to enable pre-commit hook:
+- Neovim ≥ v0.11.5
+- A [Nerd Font](https://www.nerdfonts.com/)
+- A terminal with true-color and undercurl support — [kitty](https://github.com/kovidgoyal/kitty), [wezterm](https://github.com/wez/wezterm), [alacritty](https://github.com/alacritty/alacritty), or [iterm2](https://iterm2.com/)
+
+Tool dependencies (ripgrep, fd, fzf, …) are installed by `kv install` — see [kv install docs](https://github.com/KoalaVim/kv/blob/main/docs/install.md).
+
+## Installation
+
+### Recommended: with `kv`
+
+[`kv`](https://github.com/KoalaVim/kv) is the KoalaVim launcher and environment manager. Install it first — see the [kv README](https://github.com/KoalaVim/kv#installation) for instructions.
+
+Then bootstrap a KoalaVim environment, either via the interactive wizard:
+
 ```bash
-git config --local include.path ../.gitconfig
+kv init
 ```
 
----
+…or directly from the starter template:
 
-Requirements:
-- [Nerd Font](https://www.nerdfonts.com/)
-- [ripgrep](https://github.com/BurntSushi/ripgrep)
-- [fd](https://github.com/sharkdp/fd)
-- [fzf](https://github.com/junegunn/fzf)
-- Terminal with true color and undercurl support:
-    - [kitty](https://github.com/kovidgoyal/kitty)
-    - [wezterm](https://github.com/wez/wezterm)
-    - [alacritty](https://github.com/alacritty/alacritty)
-    - [iterm2](https://iterm2.com/)
+```bash
+kv env create main --from https://github.com/KoalaVim/KoalaConfig.template
+```
 
-TODO:
-- cleanup root directory
-- fire-nvim
-- nvlog ()
-- whichkey
-- Navigate to KoalaVim's plugins directory
-- Move to personal:
-    - keymaps
-    - autocmds
-    - usercmds
+Launch KoalaVim:
+
+```bash
+kv
+```
+
+### Manual
+
+If you'd rather not use `kv`, you can install KoalaVim into the standard Neovim config location.
+
+Back up your existing Neovim config and data directories:
+
+```bash
+mv ~/.config/nvim ~/.config/nvim.bak
+mv ~/.local/share/nvim ~/.local/share/nvim.bak
+```
+
+Clone the [KoalaConfig template](https://github.com/KoalaVim/KoalaConfig.template) into `~/.config/nvim`:
+
+```bash
+git clone https://github.com/KoalaVim/KoalaConfig.template ~/.config/nvim
+rm -rf ~/.config/nvim/.git   # optional: remove if you plan to push it as your own
+```
+
+Launch Neovim:
+
+```bash
+nvim
+```
+
+The first launch installs all treesitter parsers and may be laggy. Restart Neovim after the installation completes.
+
+## Configuration
+
+KoalaVim is configured via `kvim.conf` (JSON) at your config root. The full schema lives in [`config_scheme.jsonc`](config_scheme.jsonc); the [KoalaConfig template](https://github.com/KoalaVim/KoalaConfig.template) is a working starter.
+
+Example:
+
+```json
+{
+  "editor": {
+    "indent": { "tab_size": { "min": 2, "max": 4 } }
+  },
+  "ai": {
+    "default_tool": "claude"
+  },
+  "ui": {
+    "statusline": { "icons_only": false }
+  }
+}
+```
+
+## Plugins
+
+Plugins are organized by category. See [`docs/plugins/README.md`](docs/plugins/README.md) for the full index with upstream links and per-plugin descriptions.
+
+## Contributing
+
+- Enable the pre-commit hook:
+
+  ```bash
+  git config --local include.path ../.gitconfig
+  ```
+
+- Lua formatting via [`stylua`](https://github.com/JohnnyMorganz/StyLua) (config: [`stylua.toml`](stylua.toml)).
+- Local development: create a scratch env pointing at your local KoalaVim checkout, e.g. `kv env create dev --from <path>`, or fork an existing env. See [kv env docs](https://github.com/KoalaVim/kv/blob/main/docs/envs.md).
+
+## License
+
+Licensed under [GPL-3.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Extensible Neovim distribution, powered by [lazy.nvim](https://github.com/folke/
 
 ## Features
 
-- AI sidekick integration with Claude, Codex, Cursor, and opencode CLI agents inside Neovim.
+- AI layer on top of [sidekick.nvim](https://github.com/folke/sidekick.nvim) — in-buffer edit-prompt, prompt navigation, zoom-to-tabpage, sticky default-tool selector, and fast-typing auto-edit detection.
 - Git-aware launch modes (diff, status, tree).
 - Modal sub-modes via [Hydra](docs/plugins/hydra.md).
 - Curated plugin set across 16 categories — see [`docs/plugins/`](docs/plugins/README.md).
@@ -23,9 +23,10 @@ Extensible Neovim distribution, powered by [lazy.nvim](https://github.com/folke/
 
 - Neovim ≥ v0.11.5
 - A [Nerd Font](https://www.nerdfonts.com/)
-- A terminal with true-color and undercurl support — [kitty](https://github.com/kovidgoyal/kitty), [wezterm](https://github.com/wez/wezterm), [alacritty](https://github.com/alacritty/alacritty), or [iterm2](https://iterm2.com/)
+- A terminal with true-color and undercurl support — [kitty](https://github.com/kovidgoyal/kitty), [wezterm](https://github.com/wez/wezterm), [ghostty](https://ghostty.org/), [alacritty](https://github.com/alacritty/alacritty), or [iterm2](https://iterm2.com/)
 
-Tool dependencies (ripgrep, fd, fzf, …) are installed by `kv install` — see [kv install docs](https://github.com/KoalaVim/kv/blob/main/docs/install.md).
+> [!NOTE]
+> Tool dependencies (ripgrep, fd, fzf, …) are installed by `kv install`. If you're not using `kv`, install them manually — see [kv install docs](https://github.com/KoalaVim/kv/blob/main/docs/install.md) for the full list.
 
 ## Installation
 
@@ -79,9 +80,9 @@ The first launch installs all treesitter parsers and may be laggy. Restart Neovi
 
 ## Configuration
 
-KoalaVim is configured via `kvim.conf` (JSON) at your config root. The full schema lives in [`config_scheme.jsonc`](config_scheme.jsonc); the [KoalaConfig template](https://github.com/KoalaVim/KoalaConfig.template) is a working starter.
+The common knobs are exposed via `kvim.conf` (JSON) at your config root. Full schema: [`config_scheme.jsonc`](config_scheme.jsonc). The [KoalaConfig template](https://github.com/KoalaVim/KoalaConfig.template) is a working starter.
 
-Example:
+Example `kvim.conf`:
 
 ```json
 {
@@ -96,6 +97,17 @@ Example:
   }
 }
 ```
+
+### Advanced configuration
+
+JSON only covers what's been exposed. For anything beyond — extra plugins, custom keymaps, lazy.nvim option overrides — your config root is a regular Lua project that extends KoalaVim:
+
+- `lua/plugins/*.lua` — your own [lazy.nvim plugin specs](https://lazy.folke.io/spec). Merged with KoalaVim's spec at startup.
+- `lua/config/*.lua` — options, keymaps, autocmds, usercmds. Loaded after KoalaVim's config, so it can override anything.
+- `lua/config_lazy/*.lua` — same as above but loaded after lazy.nvim finishes (`KoalaVimStarted` event).
+- `lazy_opts` in `init.lua` — override lazy.nvim setup options (e.g. default colorscheme).
+
+See the [KoalaConfig template](https://github.com/KoalaVim/KoalaConfig.template) for a working `init.lua` and examples of each.
 
 ## Plugins
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Batteries-included, extensible Neovim distribution — curated plugins, robust d
 
 ## Requirements
 
-- Neovim ≥ v0.11.5
+- Neovim ≥ v0.12.0
 - A [Nerd Font](https://www.nerdfonts.com/)
 - A terminal with true-color and undercurl support — [kitty](https://github.com/kovidgoyal/kitty), [wezterm](https://github.com/wez/wezterm), [ghostty](https://ghostty.org/), [alacritty](https://github.com/alacritty/alacritty), or [iterm2](https://iterm2.com/)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # KoalaVim
 
-Extensible Neovim distribution, powered by [lazy.nvim](https://github.com/folke/lazy.nvim) and managed by [`kv`](https://github.com/KoalaVim/kv).
+Batteries-included, extensible Neovim distribution — curated plugins, robust defaults, and terminal-first tooling. Powered by [lazy.nvim](https://github.com/folke/lazy.nvim) and managed by [`kv`](https://github.com/KoalaVim/kv).
 
 <br><br><br><br><br><br>
 
@@ -12,7 +12,7 @@ Extensible Neovim distribution, powered by [lazy.nvim](https://github.com/folke/
 
 ## Features
 
-- AI layer on top of [sidekick.nvim](https://github.com/folke/sidekick.nvim) — in-buffer edit-prompt, prompt navigation, zoom-to-tabpage, sticky default-tool selector, and fast-typing auto-edit detection.
+- Improved AI integration over [sidekick.nvim](https://github.com/folke/sidekick.nvim) — in-buffer edit-prompt, prompt navigation, zoom-to-tabpage, sticky default-tool selector, and fast-typing auto-edit detection.
 - Git-aware launch modes (diff, status, tree).
 - Modal sub-modes via [Hydra](docs/plugins/hydra.md).
 - Curated plugin set across 16 categories — see [`docs/plugins/`](docs/plugins/README.md).
@@ -25,8 +25,7 @@ Extensible Neovim distribution, powered by [lazy.nvim](https://github.com/folke/
 - A [Nerd Font](https://www.nerdfonts.com/)
 - A terminal with true-color and undercurl support — [kitty](https://github.com/kovidgoyal/kitty), [wezterm](https://github.com/wez/wezterm), [ghostty](https://ghostty.org/), [alacritty](https://github.com/alacritty/alacritty), or [iterm2](https://iterm2.com/)
 
-> [!NOTE]
-> Tool dependencies (ripgrep, fd, fzf, …) are installed by `kv install`. If you're not using `kv`, install them manually — see [kv install docs](https://github.com/KoalaVim/kv/blob/main/docs/install.md) for the full list.
+Tool dependencies (ripgrep, fd, fzf, …) are installed automatically by `kv install`.
 
 ## Installation
 
@@ -52,9 +51,12 @@ Launch KoalaVim:
 kv
 ```
 
-### Manual
+### Manual Install (Not Recommended)
 
 If you'd rather not use `kv`, you can install KoalaVim into the standard Neovim config location.
+
+> [!NOTE]
+> You'll need to install tool dependencies yourself — at minimum `ripgrep`, `fd`, and `fzf`. See the [kv install docs](https://github.com/KoalaVim/kv/blob/main/docs/install.md) for the full list.
 
 Back up your existing Neovim config and data directories:
 


### PR DESCRIPTION
## Summary

- Make [`kv`](https://github.com/KoalaVim/kv) the recommended install path; keep manual clone as a fallback.
- Add Features, Configuration, Plugins, and Contributing sections — the previous README had none of these.
- Link out to `docs/plugins/`, `config_scheme.jsonc`, and `KoalaConfig.template` rather than duplicating their contents.