### PR TITLE
zellij: add Navigator.nvim backend for cross-pane navigation

### DIFF
--- a/docs/plugins/editor.md
+++ b/docs/plugins/editor.md
@@ -14,7 +14,7 @@ General editor enhancements and QoL utilities.
 | [open.nvim](https://github.com/ofirgall/open.nvim) | Open URL/file/issue-ref under the cursor in the right external app. |
 | [open-jira.nvim](https://github.com/ofirgall/open-jira.nvim) | open.nvim handler for Jira ticket references. |
 | [nvim-retrail](https://github.com/zakharykaplan/nvim-retrail) | Highlight and trim trailing whitespace/blank lines at EOF. |
-| [Navigator.nvim](https://github.com/numToStr/Navigator.nvim) | Unified window navigation between Neovim splits and tmux/wezterm panes. |
+| [Navigator.nvim](https://github.com/numToStr/Navigator.nvim) | Unified window navigation between Neovim splits and tmux/wezterm/zellij panes. |
 | [hex.nvim](https://github.com/RaafatTurki/hex.nvim) | Toggle current buffer between text and hexdump view. |
 | [suda.vim](https://github.com/lambdalisue/suda.vim) | Read/write files requiring sudo from inside Neovim. |
 | [vim-buffest](https://github.com/rbong/vim-buffest) | Edit quickfix, location list and registers as regular buffers. |
@@ -33,3 +33,25 @@ General editor enhancements and QoL utilities.
 | [marks.nvim](https://github.com/ofirgall/marks.nvim) | Visual sign column for Vim marks plus enhanced mark bindings. |
 | [snacks.nvim](https://github.com/folke/snacks.nvim) | folke QoL grab-bag: notifier, dim, scroll, input, picker, dashboard, etc. |
 | [nerdy.nvim](https://github.com/2kabhishek/nerdy.nvim) | Browse and insert Nerd Font icons from a picker. |
+
+## Zellij navigation
+
+Navigator.nvim has no zellij backend upstream, so KoalaVim supplies one
+(`KoalaVim.utils.plugins.navigator_zellij`). It is selected when `$ZELLIJ` is
+set, which also means it wins over wezterm when zellij is nested inside it — the
+innermost multiplexer owns the pane Neovim lives in.
+
+Two things are needed on the zellij side, neither of which KoalaVim can do for
+you:
+
+- **Zellij must be in locked mode while nvim is focused**, otherwise zellij
+  keeps `<C-hjkl>` for itself and Neovim never sees the keys. The
+  [zellij-autolock](https://github.com/fresh2dev/zellij-autolock) plugin does
+  this automatically; it matches on the pane's running command, so a wrapper
+  script around nvim needs to be added to its trigger list. `zellij action
+  list-clients` shows the command it matches against.
+- **`zellij` must be on `PATH`.** Handoff shells out to `zellij action`; a
+  failure surfaces as a warning notification rather than failing silently.
+
+Navigation is pane-scoped in every direction and never crosses zellij tabs,
+matching the tmux and wezterm backends. At the edge of the tab, focus stays put.

--- a/lua/KoalaVim/plugins/editor.lua
+++ b/lua/KoalaVim/plugins/editor.lua
@@ -358,13 +358,23 @@ table.insert(M, {
 	end,
 })
 
--- Unified window navigation between Neovim splits and tmux/wezterm panes
+-- Unified window navigation between Neovim splits and tmux/wezterm/zellij panes
 table.insert(M, {
 	'numToStr/Navigator.nvim',
 	opts = {
 		disable_on_zoom = false,
 	},
 	config = function(_, opts)
+		-- Navigator ships no zellij backend. Checked before 'auto' detection because
+		-- zellij nested inside wezterm sets both $ZELLIJ and TERM_PROGRAM=WezTerm,
+		-- and the innermost multiplexer owns the pane we live in.
+		if vim.env.ZELLIJ ~= nil then
+			local ok, zellij = pcall(function()
+				return require('KoalaVim.utils.plugins.navigator_zellij'):new()
+			end)
+			opts.mux = ok and zellij or 'auto'
+		end
+
 		require('Navigator').setup(opts)
 	end,
 	cmd = { 'NavigatorLeft', 'NavigatorRight', 'NavigatorDown', 'NavigatorUp' },

--- a/lua/KoalaVim/plugins/lsp/servers/markdown.lua
+++ b/lua/KoalaVim/plugins/lsp/servers/markdown.lua
@@ -146,7 +146,13 @@ table.insert(M, {
 			mode = 'n',
 			desc = 'Cycle todo previous',
 		},
-		{ '<leader>th', '<cmd>Checkmate cycle_previous<CR>', ft = 'markdown', mode = 'v', desc = 'Cycle todo previous' },
+		{
+			'<leader>th',
+			'<cmd>Checkmate cycle_previous<CR>',
+			ft = 'markdown',
+			mode = 'v',
+			desc = 'Cycle todo previous',
+		},
 		{ '<leader>tn', '<cmd>Checkmate create<CR>', ft = 'markdown', mode = { 'n', 'v' }, desc = 'Create todo item' },
 		{
 			'<leader>tr',

--- a/lua/KoalaVim/plugins/lsp/servers/python.lua
+++ b/lua/KoalaVim/plugins/lsp/servers/python.lua
@@ -55,5 +55,4 @@ NONE_LS_SRCS['mypy'] = {
 CONFORM_FORMATTERS['black'] = { 'python' }
 CONFORM_FORMATTERS['ruff_format'] = { 'python', mason = 'ruff' }
 
-
 return M

--- a/lua/KoalaVim/utils/plugins/navigator_zellij.lua
+++ b/lua/KoalaVim/utils/plugins/navigator_zellij.lua
@@ -1,0 +1,56 @@
+-- Zellij multiplexer backend for Navigator.nvim.
+--
+-- Navigator runs `wincmd <dir>` first and only calls us once the cursor is
+-- already at the edge of Neovim's layout, where we hand focus to the neighbouring
+-- Zellij pane.
+--
+-- Requires Zellij to be in "locked" mode while nvim is focused (zellij-autolock
+-- does this), otherwise Zellij keeps <C-hjkl> and none of this runs.
+
+---@private
+---@class KoalaZellij: Vi
+---@field private directions table<Direction, string[]>
+local Zellij = require('Navigator.mux.vi'):new()
+
+-- `zellij action` argument lists per direction. Lists rather than fixed
+-- {action, direction} pairs because `p` (NavigatorPrevious) takes no direction.
+local directions = {
+	h = { 'move-focus', 'left' },
+	j = { 'move-focus', 'down' },
+	k = { 'move-focus', 'up' },
+	l = { 'move-focus', 'right' },
+	p = { 'focus-previous-pane' },
+}
+
+---Creates a new Zellij navigator instance
+---@return KoalaZellij
+function Zellij:new()
+	assert(vim.env.ZELLIJ ~= nil, '[Navigator] Zellij is not running!')
+
+	self.__index = self
+	return setmetatable({ directions = directions }, self)
+end
+
+---Switch pane in Zellij
+---@param direction Direction See |navigator.api.Direction|
+---@return KoalaZellij
+function Zellij:navigate(direction)
+	local args = self.directions[direction]
+	if args == nil then
+		return self
+	end
+
+	-- Fire and forget: nothing downstream waits on the focus change.
+	vim.system({ 'zellij', 'action', unpack(args) }, { text = true }, function(out)
+		if out.code ~= 0 then
+			local msg = vim.trim((out.stderr or ''):gsub('%s+', ' '))
+			vim.schedule(function()
+				vim.notify('zellij action failed: ' .. msg, vim.log.levels.WARN)
+			end)
+		end
+	end)
+
+	return self
+end
+
+return Zellij

--- a/openspec/changes/archive/2026-07-29-add-zellij-navigation/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-29-add-zellij-navigation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/archive/2026-07-29-add-zellij-navigation/design.md
+++ b/openspec/changes/archive/2026-07-29-add-zellij-navigation/design.md
@@ -1,0 +1,92 @@
+## Context
+
+KoalaVim binds `<C-h/j/k/l>` in normal and terminal mode to `NavigatorLeft/Down/Up/Right` (`lua/KoalaVim/plugins/editor.lua`), and sidekick.nvim's CLI window reuses the same commands for its `nav_*` keys (`lua/KoalaVim/plugins/ai.lua`). Navigator.nvim owns the interesting part of that behaviour: it runs `wincmd <dir>`, compares the window id before and after, and only signals the multiplexer when the window did not change (i.e. the cursor was already at the edge). It also tracks a `last_pane` flag so a second press keeps travelling outward, and clears it on `WinEnter`.
+
+Navigator ships three mux backends under `lua/Navigator/mux/`: `tmux`, `wezterm`, and `vi` (a no-op base class used when nothing is detected). `Navigator.navigate.load_mux()` probes tmux, then WezTerm, then falls back to `vi`. There is no Zellij backend, so inside a Zellij session `<C-hjkl>` dies at the edge of the Neovim layout.
+
+A working implementation already exists outside this repo at `configs/nvim-atom/lua/atom/zellij.lua`. It re-implements the edge detection itself and shells out to `zellij action` asynchronously via `vim.system`, warning on a non-zero exit. It uses `move-focus-or-tab` for horizontal moves, mirroring the `MoveFocusOrTab` bindings in that author's `configs/zellij/config.kdl`; KoalaVim deliberately does not (see Decision 3).
+
+The Zellij half of the handoff — Zellij must be in locked mode for `<C-hjkl>` to reach Neovim at all, which `zellij-autolock` arranges whenever the focused pane runs `nvim` — lives in the user's dotfiles and is a prerequisite, not part of this change.
+
+Constraint: KoalaVim is a shared distribution. Zellij support must be additive and inert for users on tmux, WezTerm, or no multiplexer.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `<C-h/j/k/l>` hands focus to the neighbouring Zellij pane when the cursor is at the edge of Neovim's window layout.
+- Reuse Navigator's edge detection, `last_pane` follow-through, `WinEnter` reset, and existing keymaps instead of re-implementing them.
+- Preserve tmux, WezTerm, and no-multiplexer behaviour exactly.
+- Correct behaviour when Zellij is nested inside another multiplexer.
+- A failed `zellij` invocation is visible, not swallowed.
+
+**Non-Goals:**
+
+- Zellij-side configuration (`config.kdl` keybindings, `zellij-autolock`). Documented as a prerequisite only.
+- Upstreaming the backend to numToStr/Navigator.nvim. Worth doing later; out of scope here.
+- Zoom/fullscreen awareness (see Decision 5).
+- User-facing configuration for the tab-fallthrough behaviour (see Decision 3).
+- New keymaps or changes to existing ones.
+
+## Decisions
+
+### 1. Implement Navigator's mux interface rather than replacing Navigator
+
+Add `lua/KoalaVim/utils/plugins/navigator_zellij.lua` — a class extending `require('Navigator.mux.vi')` with `new()`, `navigate(direction)`, and `zoomed()`, following the shape of the upstream `wezterm` backend. Navigator documents this as its custom-multiplexer extension point.
+
+*Alternative considered:* port `atom/zellij.lua` verbatim and drop Navigator.nvim. Rejected — it duplicates edge detection and `last_pane` follow-through, and would remove tmux/WezTerm support that other KoalaVim users depend on.
+
+*Coupling risk accepted:* the backend depends on Navigator's internal module path `Navigator.mux.vi`. It is the documented extension point, and Navigator is pinned in `lazy-lock.json`.
+
+### 2. Select the backend explicitly by `$ZELLIJ`, do not touch `load_mux()`
+
+The Navigator plugin spec resolves `opts.mux` in its `config` function: if `vim.env.ZELLIJ` is set, `pcall` the Zellij backend's constructor and pass the instance; otherwise pass `'auto'` and let Navigator probe tmux → WezTerm → `vi` as it does today.
+
+This is required for correctness, not just convenience: Zellij nested inside WezTerm sets both `$ZELLIJ` and `TERM_PROGRAM=WezTerm`, and Navigator's `load_mux()` would pick WezTerm. Zellij is the innermost multiplexer and owns the pane Neovim sits in, so it must win. Resolving at `config` time also keeps the decision in one readable place instead of monkey-patching detection order.
+
+The `pcall` keeps a constructor failure non-fatal: it degrades to `'auto'`, matching today's behaviour rather than breaking navigation entirely.
+
+*Alternative considered:* `assert(vim.env.ZELLIJ)` inside `new()` and letting a patched `load_mux()` probe Zellij first. Rejected — patching upstream detection order is more fragile than deciding at the call site. The `assert` in `new()` is still kept as a guard, so the constructor is honest when called directly.
+
+### 3. `move-focus` in every direction — pane-scoped, never crossing tabs
+
+The direction table maps all of `h`/`j`/`k`/`l` to `move-focus`.
+
+The source module uses `move-focus-or-tab` for `h`/`l`, so horizontal travel falls through to the adjacent tab at the session edge. That mirrors its author's `config.kdl`, but it is the wrong default for KoalaVim: both existing backends are strictly pane-scoped and stop at the edge — tmux uses `select-pane -LRUD` and wezterm `activate-pane-direction`, neither of which switches window or tab. Adopting the fallthrough would make zellij the only backend where `<C-h>` can teleport you to a different tab. Consistency across backends wins over fidelity to the source module.
+
+Left as a module-level constant rather than a user option: adding a config-scheme knob for a five-line table is not worth the surface area, and no second consumer exists yet.
+
+### 4. `direction = 'p'` maps to `focus-previous-pane`
+
+Navigator's `Direction` alias includes `p` (previous pane), reachable via `NavigatorPrevious`. KoalaVim does not bind it, but the backend must not `nil`-index if something calls it. `p` maps to `zellij action focus-previous-pane`, which takes no direction argument — so the command table stores an argument list per direction rather than a fixed `{action, direction}` pair.
+
+### 5. `zoomed()` returns `false`
+
+Navigator only calls `zoomed()` when `disable_on_zoom` is true, and KoalaVim sets it to `false`. A real answer would need a synchronous `zellij action list-panes` parse on every keypress; not worth it for a code path that is never taken. Inheriting `vi`'s `false` is sufficient, and the reasoning is worth a comment so the omission does not read as an oversight.
+
+### 6. Async `vim.system`, warn on non-zero exit
+
+Spawn `{ 'zellij', 'action', ... }` through `vim.system` with a completion callback; on a non-zero exit, `vim.schedule` a `vim.log.levels.WARN` notification carrying the collapsed stderr. Navigator's own backends use blocking `io.popen`, which stalls the UI on every edge press — no reason to inherit that. `navigate()` still returns `self` to honour the interface contract; Navigator ignores the return value.
+
+Note that `auto_save` is unset in KoalaVim's Navigator opts, so nothing in Navigator's post-handoff path depends on the `zellij` call having completed. Async is safe here.
+
+### 7. Verification is manual
+
+There is no test harness for keymaps or multiplexer handoff in this repo, and the behaviour is inherently interactive. Verification is a documented manual checklist (inside Zellij, outside Zellij, nested under WezTerm, forced-failure notification) plus `stylua --check` and a `:lua` load check.
+
+## Risks / Trade-offs
+
+- **Navigator's internal `Navigator.mux.vi` path changes upstream** → the `pcall` around the constructor degrades to `mux = 'auto'` instead of breaking navigation; Navigator is version-pinned in `lazy-lock.json`, so a break can only arrive with a deliberate update.
+- **`zellij` binary missing from `PATH` while `$ZELLIJ` is set** → `vim.system` fails and the error surfaces as the same warning notification; Neovim-internal navigation is unaffected.
+- **Async fire-and-forget means rapid `<C-h>` presses could race** → each press is an independent focus command and Zellij serialises them; the worst case is over-travel, which is also what tmux users get today.
+- **Zellij not in locked mode** → `<C-hjkl>` never reaches Neovim, so this code appears dead. Not fixable from Neovim; called out explicitly in the docs so the failure is diagnosable.
+- **Zoom is ignored** → navigating out of a zoomed Zellij pane un-zooms rather than being suppressed. Accepted; `disable_on_zoom` is `false` today, so this matches current tmux/WezTerm behaviour in this config.
+- **This repo is checked out twice** (`~/.local/share/kvim-envs/main/lazy/KoalaVim` and `~/workspaces/personal/koala/KoalaVim`, both on the same commit). Implementation lands in the OpenSpec planning root; the other clone picks it up via `git`, not by a second manual edit.
+
+## Migration Plan
+
+Additive; no migration. Rollback is reverting the two edits — `mux = 'auto'` restores today's behaviour, and the new file becomes dead code.
+
+## Open Questions
+
+- Should the backend be contributed upstream to numToStr/Navigator.nvim so `load_mux()` probes Zellij natively? Deferred; local first, upstream once it has been used in anger.

--- a/openspec/changes/archive/2026-07-29-add-zellij-navigation/proposal.md
+++ b/openspec/changes/archive/2026-07-29-add-zellij-navigation/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+`<C-h/j/k/l>` currently hands focus off to a neighbouring terminal-multiplexer pane only under tmux or WezTerm, because those are the only backends Navigator.nvim ships. Inside a Zellij session the keys stop dead at the edge of Neovim's window layout, so navigation silently breaks for Zellij users. A working port already exists outside this repo (`configs/nvim-atom/lua/atom/zellij.lua`) and should become a first-class KoalaVim backend.
+
+## What Changes
+
+- Add a Zellij multiplexer backend for Navigator.nvim, living in KoalaVim and implementing Navigator's `Vi` mux interface (`new`, `navigate`, `zoomed`).
+- Select that backend explicitly when `$ZELLIJ` is set, so Zellij wins over WezTerm when Neovim runs in a Zellij pane inside WezTerm (Zellij is the innermost multiplexer and owns the pane layout Neovim sits in).
+- Fall back to Navigator's existing `mux = 'auto'` detection (tmux → WezTerm → no-op) when `$ZELLIJ` is absent, leaving current behaviour byte-identical for non-Zellij users.
+- All four directions use `zellij action move-focus`, keeping navigation pane-scoped and never crossing Zellij tabs, matching the tmux (`select-pane -LRUD`) and wezterm (`activate-pane-direction`) backends.
+- Run the `zellij` CLI asynchronously via `vim.system` and surface a warning notification when the action exits non-zero, so a failed handoff is visible instead of silent.
+- Document the backend and its Zellij-side prerequisite (Zellij must be in locked mode — e.g. via `zellij-autolock` — for `<C-hjkl>` to reach Neovim at all).
+- No keymap changes: `<C-h/j/k/l>` in normal and terminal mode, plus the sidekick.nvim CLI window nav keys, keep calling `Navigator*` commands.
+
+## Capabilities
+
+### New Capabilities
+
+None. This extends an existing capability rather than introducing a new one.
+
+### Modified Capabilities
+
+- `editor-enhancements`: the **Cross-pane navigation** requirement currently names tmux and WezTerm as the supported multiplexers. It gains Zellij, the innermost-multiplexer selection rule, and the requirement that a failed multiplexer handoff is reported rather than swallowed.
+
+## Impact
+
+- **New file**: `lua/KoalaVim/utils/plugins/navigator_zellij.lua` — the mux backend.
+- **Modified**: `lua/KoalaVim/plugins/editor.lua` — the `numToStr/Navigator.nvim` spec passes the resolved `mux` in `config`.
+- **Modified**: `docs/plugins/editor.md` — the Navigator.nvim row mentions Zellij.
+- **Dependencies**: no new plugins. Depends on Navigator.nvim's internal `Navigator.mux.vi` base class, which is documented as the extension point for custom multiplexers, and on the `zellij` binary being on `PATH` inside a Zellij session.
+- **Out of scope**: the Zellij side of the contract (`config.kdl` keybindings, the `zellij-autolock` plugin) lives in the user's dotfiles, not in KoalaVim. It is documented as a prerequisite only.
+- **Unaffected**: `<C-hjkl>` keymaps, tmux/WezTerm users, `disable_on_zoom = false`, and the sidekick.nvim nav keys.

--- a/openspec/changes/archive/2026-07-29-add-zellij-navigation/specs/editor-enhancements/spec.md
+++ b/openspec/changes/archive/2026-07-29-add-zellij-navigation/specs/editor-enhancements/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Cross-pane navigation
+
+The system SHALL provide unified window navigation that works across editor splits and terminal multiplexer panes (tmux, wezterm, zellij). The same key bindings SHALL move focus seamlessly between editor and multiplexer boundaries.
+
+When several multiplexers are nested, the system SHALL drive the innermost one — the multiplexer that owns the pane the editor occupies. Specifically, when the editor runs inside a Zellij session the Zellij backend SHALL be used regardless of any outer multiplexer.
+
+Handoff to the multiplexer SHALL NOT block the editor. When a multiplexer handoff fails, the system SHALL notify the user at warning level rather than failing silently.
+
+#### Scenario: Navigate from editor to multiplexer pane
+- **WHEN** the user presses the right-navigation key while in the rightmost editor split
+- **THEN** focus SHALL move to the adjacent multiplexer pane to the right
+
+#### Scenario: Navigate between editor splits
+- **WHEN** the user presses a navigation key and an editor split exists in that direction
+- **THEN** focus SHALL move to that split and no multiplexer command SHALL be issued
+
+#### Scenario: Navigation does not cross multiplexer tabs
+- **WHEN** the user presses a navigation key in any direction while at the edge of both the editor layout and the multiplexer's pane layout
+- **THEN** focus SHALL remain where it is and SHALL NOT move to another multiplexer tab or window
+
+#### Scenario: Zellij takes priority over an outer multiplexer
+- **WHEN** the editor runs in a Zellij pane that is itself inside a WezTerm or tmux pane and the user presses a navigation key at the editor's edge
+- **THEN** the Zellij backend SHALL be driven and the outer multiplexer SHALL NOT be signalled
+
+#### Scenario: Editor outside any multiplexer
+- **WHEN** the user presses a navigation key at the edge of the editor's layout with no multiplexer present
+- **THEN** focus SHALL remain unchanged, no multiplexer command SHALL be issued, and no error SHALL be reported
+
+#### Scenario: Failed multiplexer handoff is reported
+- **WHEN** a multiplexer focus command is issued and exits with a non-zero status
+- **THEN** the system SHALL emit a warning notification identifying the failure, and the editor SHALL remain usable

--- a/openspec/changes/archive/2026-07-29-add-zellij-navigation/tasks.md
+++ b/openspec/changes/archive/2026-07-29-add-zellij-navigation/tasks.md
@@ -1,0 +1,67 @@
+## 1. Zellij mux backend
+
+- [x] 1.1 Create `lua/KoalaVim/utils/plugins/navigator_zellij.lua` as a class extending `require('Navigator.mux.vi')`, following the shape of upstream `Navigator.mux.wezterm`; use tab indentation and single quotes per `stylua.toml`
+- [x] 1.2 Add the direction → CLI argument table: `move-focus` for all of `h`/`j`/`k`/`l` (pane-scoped, never crossing tabs, matching the tmux and wezterm backends) plus `p` = `{ 'focus-previous-pane' }` (argument lists, not fixed pairs — `p` takes no direction)
+- [x] 1.3 Implement `Zellij:new()` with `assert(vim.env.ZELLIJ ~= nil, ...)` so a direct call fails honestly, returning a `setmetatable` instance like the wezterm backend
+- [x] 1.4 Implement `Zellij:navigate(direction)`: look up the argument list, spawn `{ 'zellij', 'action', unpack(args) }` via `vim.system` with `{ text = true }`, and `return self`; make an unknown direction a no-op rather than a `nil` index
+- [x] 1.5 In the `vim.system` callback, on non-zero exit `vim.schedule` a `vim.notify` at `vim.log.levels.WARN` with the collapsed stderr (`vim.trim(stderr:gsub('%s+', ' '))`)
+- [x] 1.6 Add a comment explaining that `zoomed()` is inherited from `vi` and returns `false` on purpose — Navigator only calls it when `disable_on_zoom` is true, and querying Zellij fullscreen would need a blocking `list-panes` on every keypress
+- [x] 1.7 Add a header comment covering the two-sided contract: Zellij must be in locked mode (e.g. via `zellij-autolock`) for `<C-hjkl>` to reach Neovim, and this module handles the other direction — handing focus off once Neovim is already at its own edge
+
+## 2. Wire the backend into Navigator
+
+- [x] 2.1 In `lua/KoalaVim/plugins/editor.lua`, in the `numToStr/Navigator.nvim` spec's `config` function, resolve the mux before `setup`: when `vim.env.ZELLIJ` is set, `pcall` the Zellij backend's `new()` and use the instance; otherwise leave `mux = 'auto'`
+- [x] 2.2 Make a failed `pcall` fall back to `'auto'` rather than erroring, so a Navigator internals change degrades to today's behaviour
+- [x] 2.3 Add a comment stating why `$ZELLIJ` is checked instead of extending Navigator's `load_mux()`: Zellij nested inside WezTerm sets both `$ZELLIJ` and `TERM_PROGRAM=WezTerm`, and the innermost multiplexer must win
+- [x] 2.4 Update the plugin's leading comment from "tmux/wezterm panes" to include zellij; leave `disable_on_zoom = false` and all `<C-h/j/k/l>` keymaps untouched
+
+## 3. Documentation
+
+- [x] 3.1 Update the Navigator.nvim row in `docs/plugins/editor.md` to name zellij alongside tmux/wezterm
+- [x] 3.2 Note the Zellij-side prerequisite (locked mode via `zellij-autolock`, `zellij` on `PATH`) so a non-working setup is diagnosable
+
+## 4. Verification
+
+- [x] 4.1 Run `stylua --check` (or `make` if it wraps formatting) over the new and modified files
+- [x] 4.2 Load check outside Zellij: start Neovim, confirm `:lua print(require('Navigator.navigate').config.mux)` is not the Zellij backend and that `<C-h/j/k/l>` still move between splits with no errors
+- [x] 4.3 Manual check inside a Zellij session with a pane to the left of Neovim: from the leftmost split, `<C-h>` moves focus to that Zellij pane; with a split to the left, `<C-h>` moves within Neovim and issues no `zellij` command
+- [x] 4.4 Manual check that no direction crosses a Zellij tab at the session edge
+- [ ] 4.5 Manual check in terminal mode and in the sidekick.nvim CLI split that the same keys hand off correctly
+- [x] 4.6 Force a failure (e.g. temporarily point the command at a bogus zellij action) and confirm a WARN notification appears and Neovim stays usable
+- [ ] 4.7 If a nested setup is available, confirm Zellij-inside-WezTerm drives Zellij and not WezTerm
+
+## Verification notes
+
+Verified from inside a live Zellij session (`$ZELLIJ=0`) running the real
+KoalaVim config headless via `kv --headless`. Focus-move commands were asserted
+by intercepting `vim.system` and checking the exact argv, so the live session was
+never disturbed.
+
+- 4.1 — `stylua --check` clean on both changed Lua files.
+- 4.2 — With `ZELLIJ` unset, the resolved mux is *not* the Zellij backend,
+  `disable_on_zoom` stays `false`, `auto_save` stays `nil`, and all four
+  `<C-hjkl>` keymaps still resolve to `<Cmd>Navigator*<CR>`. With `$ZELLIJ` set,
+  the resolved mux *is* the Zellij backend.
+- 4.3 / 4.4 — Asserted at the argv level: a split in the direction moves within
+  Neovim and issues no `zellij` command; at the edge the window is unchanged and
+  exactly `move-focus <left|right|up|down>` is issued, never
+  `move-focus-or-tab`. Observing focus actually land in the neighbouring Zellij
+  pane is really a check of Zellij itself and was not driven.
+- 4.5 — Partial. All four `<C-hjkl>` are confirmed mapped in terminal mode. The
+  sidekick.nvim CLI split was not exercised (needs a live AI CLI session); it
+  reuses the same `Navigator*` commands, so no separate code path is involved.
+- 4.6 — Real `vim.system` spawn with a bogus action produced a
+  `vim.log.levels.WARN` notification prefixed `zellij action failed: ` carrying
+  the collapsed stderr; Neovim stayed usable.
+- 4.7 — Not verifiable here: the host terminal is ghostty, so no WezTerm layer
+  exists to nest under. The `$ZELLIJ` check makes the outcome deterministic by
+  construction, but it is unexercised.
+
+Also confirmed directly: `new()` asserts when `$ZELLIJ` is absent, `zoomed()`
+inherits `false` from `Navigator.mux.vi`, an unknown direction is a no-op
+returning `self` rather than a `nil` index, and `p` maps to
+`focus-previous-pane` with no direction argument.
+
+Scratch harnesses used (not added to the repo — there is no Lua test harness to
+slot them into): `test_zellij.lua` (backend unit checks), `check_wiring.lua`
+(mux resolution + keymaps), `check_handoff.lua` (edge detection + argv).

--- a/openspec/specs/editor-enhancements/spec.md
+++ b/openspec/specs/editor-enhancements/spec.md
@@ -1,9 +1,7 @@
 ## Purpose
 
 Editor enhancements improve everyday editing workflows: auto-saving, indentation detection, split zoom, whitespace management, file operations, find/replace, undo visualization, diagnostics browsing, and various quality-of-life features that make text editing more efficient.
-
 ## Requirements
-
 ### Requirement: Automatic file saving
 
 The system SHALL automatically save files when leaving insert mode and on text changes. Saving SHALL be skipped for hex-mode buffers and non-normal editor modes.
@@ -66,11 +64,37 @@ The system SHALL highlight trailing whitespace in real-time and trim trailing wh
 
 ### Requirement: Cross-pane navigation
 
-The system SHALL provide unified window navigation that works across editor splits and terminal multiplexer panes (tmux, wezterm). The same key bindings SHALL move focus seamlessly between editor and multiplexer boundaries.
+The system SHALL provide unified window navigation that works across editor splits and terminal multiplexer panes (tmux, wezterm, zellij). The same key bindings SHALL move focus seamlessly between editor and multiplexer boundaries.
+
+Navigation SHALL be pane-scoped for every multiplexer: focus SHALL move between panes only and SHALL NOT cross the multiplexer's tab or window boundary. At the edge of the multiplexer's pane layout, focus SHALL remain where it is.
+
+When several multiplexers are nested, the system SHALL drive the innermost one — the multiplexer that owns the pane the editor occupies. Specifically, when the editor runs inside a Zellij session the Zellij backend SHALL be used regardless of any outer multiplexer.
+
+Handoff to the multiplexer SHALL NOT block the editor. When a multiplexer handoff fails, the system SHALL notify the user at warning level rather than failing silently.
 
 #### Scenario: Navigate from editor to multiplexer pane
 - **WHEN** the user presses the right-navigation key while in the rightmost editor split
 - **THEN** focus SHALL move to the adjacent multiplexer pane to the right
+
+#### Scenario: Navigate between editor splits
+- **WHEN** the user presses a navigation key and an editor split exists in that direction
+- **THEN** focus SHALL move to that split and no multiplexer command SHALL be issued
+
+#### Scenario: Navigation does not cross multiplexer tabs
+- **WHEN** the user presses a navigation key in any direction while at the edge of both the editor layout and the multiplexer's pane layout
+- **THEN** focus SHALL remain where it is and SHALL NOT move to another multiplexer tab or window
+
+#### Scenario: Zellij takes priority over an outer multiplexer
+- **WHEN** the editor runs in a Zellij pane that is itself inside a WezTerm or tmux pane and the user presses a navigation key at the editor's edge
+- **THEN** the Zellij backend SHALL be driven and the outer multiplexer SHALL NOT be signalled
+
+#### Scenario: Editor outside any multiplexer
+- **WHEN** the user presses a navigation key at the edge of the editor's layout with no multiplexer present
+- **THEN** focus SHALL remain unchanged, no multiplexer command SHALL be issued, and no error SHALL be reported
+
+#### Scenario: Failed multiplexer handoff is reported
+- **WHEN** a multiplexer focus command is issued and exits with a non-zero status
+- **THEN** the system SHALL emit a warning notification identifying the failure, and the editor SHALL remain usable
 
 ### Requirement: Hex viewer
 


### PR DESCRIPTION
## Why

Navigator.nvim ships `tmux` and `wezterm` backends only. Inside a zellij session `<C-hjkl>` stopped dead at the edge of Neovim's window layout instead of handing focus to the neighbouring pane, so cross-pane navigation silently didn't work for zellij users.

## What

- New `lua/KoalaVim/utils/plugins/navigator_zellij.lua` — a mux backend implementing Navigator's `Vi` interface (its documented extension point).
- `editor.lua` selects it when `$ZELLIJ` is set, otherwise leaves Navigator's `mux = 'auto'` untouched.

Checking the env var rather than extending Navigator's `auto` detection is deliberate: `auto` probes tmux → wezterm, and zellij nested inside wezterm sets both `$ZELLIJ` and `TERM_PROGRAM=WezTerm`, so `auto` would drive the *outer* multiplexer. The innermost one owns the pane Neovim lives in. A failed constructor degrades to `'auto'` rather than breaking navigation.

All four directions use `zellij action move-focus`, keeping navigation pane-scoped like the existing backends — tmux's `select-pane -LRUD` and wezterm's `activate-pane-direction` both stop at the edge rather than crossing a tab. The CLI call is async via `vim.system` and warns on a non-zero exit instead of failing silently.

Unchanged: `<C-hjkl>` keymaps, `disable_on_zoom`, the sidekick.nvim nav keys, and behaviour for tmux/wezterm/no-multiplexer users.

## Prerequisite

This only runs if **zellij is in locked mode while nvim is focused** — otherwise zellij keeps `<C-hjkl>` and Neovim never sees the keys. [zellij-autolock](https://github.com/fresh2dev/zellij-autolock) handles it, matching on the pane's running command (so a wrapper script needs adding to its trigger list). Documented in `docs/plugins/editor.md`.

## Verification

Run from inside a live zellij session against the real config. Focus commands were asserted by intercepting `vim.system` and checking the exact argv, so no live panes were disturbed.

- Mux resolution both ways: `$ZELLIJ` set → zellij backend; unset → `auto` detection, keymaps intact
- Edge detection: a split in the direction moves within Neovim and issues **zero** `zellij` commands; at the edge the window is unchanged and exactly `move-focus <left|right|up|down>` is issued, never `move-focus-or-tab`
- Failure path: real spawn with a bogus action → `WARN` notification with collapsed stderr, editor stays usable
- `new()` asserts without `$ZELLIJ`; `zoomed()` inherits `false`; unknown direction is a no-op; `p` → `focus-previous-pane`
- `stylua --check` clean; `openspec validate --specs` 14/14

Not verified: the sidekick.nvim CLI split (needs a live AI CLI session; same `Navigator*` commands, no separate code path), and zellij-nested-in-wezterm (no wezterm host available).

## Specs

`openspec/specs/editor-enhancements/spec.md` — *Cross-pane navigation* gains zellij, the pane-scoped rule, the innermost-multiplexer rule, and the report-on-failure rule. Planning artifacts are archived under `openspec/changes/archive/`.