### PR TITLE
fix(fff): use ofirkai highlights

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -91,7 +91,7 @@
   "nvim-vtsls": { "branch": "main", "commit": "0b5f73c9e50ce95842ea07bb3f05c7d66d87d14a" },
   "nvim-web-devicons": { "branch": "master", "commit": "803353450c374192393f5387b6a0176d0972b848" },
   "octo.nvim": { "branch": "master", "commit": "4a3a4fc5a9d3a372c91041f5b846f33b8d6b31fa" },
-  "ofirkai.nvim": { "branch": "master", "commit": "e4d527a0a446fbe9e7e537e198a25cfce20346a1" },
+  "ofirkai.nvim": { "branch": "master", "commit": "ffa1eab6c3955fa966dddedf9fb73999c5b6a42d" },
   "open-jira.nvim": { "branch": "master", "commit": "dcbe121d675df64f93aa0e50f32c86a1d7439e28" },
   "open.nvim": { "branch": "master", "commit": "f00d07e2cbf79a10874bce02b462cb9b0aac7435" },
   "output-panel.nvim": { "branch": "main", "commit": "3f199ff9e7d56fa30e39edfb07a883ef4142cd98" },

--- a/lua/KoalaVim/plugins/pickers.lua
+++ b/lua/KoalaVim/plugins/pickers.lua
@@ -99,6 +99,11 @@ table.insert(M, {
 		require('fff.download').download_or_build_binary()
 	end,
 	lazy = false,
+	config = function(_, opts)
+		-- Required at load time, ofirkai isn't on the rtp when the spec is read
+		opts.hl = require('ofirkai.plugins.fff').hl
+		require('fff').setup(opts)
+	end,
 	opts = {
 		prompt_vim_mode = true,
 		keymaps = {
@@ -114,21 +119,6 @@ table.insert(M, {
 			width = 0.9,
 			preview_size = 0.5,
 			prompt_position = 'bottom',
-		},
-		hl = {
-			normal = 'FffNormal',
-			border = 'FffBorder',
-			title = 'FffTitle',
-			prompt = 'FffPrompt',
-			cursorline = 'FffCursorLine',
-			matched = 'FffMatched',
-			selected = 'FffSelected',
-			selected_active = 'FffSelectedActive',
-			frecency = 'FffFrecency',
-			directory_path = 'FffDirectory',
-			winhl = {
-				preview = 'Normal:FffPreviewNormal,FloatBorder:FffPreviewBorder,FloatTitle:FffPreviewTitle',
-			},
 		},
 	},
 	keys = {


### PR DESCRIPTION
## Summary
- Use `ofirkai.plugins.fff` highlight definitions instead of hardcoded highlight group names
- Update `ofirkai.nvim` lockfile to the version that exports fff highlights

## Test plan
- [x] Open fff picker and verify highlight groups are applied correctly